### PR TITLE
feat: Add Context Caching for Multi-turn Conversation Support

### DIFF
--- a/AS-FAQ-RAG/config/prompts/prompts.yaml.example
+++ b/AS-FAQ-RAG/config/prompts/prompts.yaml.example
@@ -8,12 +8,18 @@ LANGUAGE_DETECTION_PROMPT: |
     Only reply with the language code.
 
 QA_PROMPT: |
+    對話歷史：
+    {previous_chat}
+
     這是和這個問題可能相關的背景知識
     {context}
 
     使用者的問題: {query}，以 {lang} 回覆
 
 QA_PROMPT_EN: |
+    Conversation History:
+    {previous_chat}
+    
     Background Knowledge: This is background knowledge that may be related to this question.
     {context}
 

--- a/AS-FAQ-Web-ChatBot/server.js
+++ b/AS-FAQ-Web-ChatBot/server.js
@@ -56,7 +56,7 @@ app.post(['/eip/askbot', '/askbot'], async (req, res) => { // "/eip/askbot" for 
   try {
     const apiUrl = `${process.env.BACKEND_URL}/ask`;
     const response = await axios.post(apiUrl, { question, chat_history: currentChatHistory });
-    const {answer, sources, chat_history: updatedChatHistory} = response.data.answer;
+    const {answer, sources, chat_history: updatedChatHistory} = response.data;
 
     res.json({ answer, sources, chat_history: updatedChatHistory });
   } catch (error) {

--- a/AS-FAQ-Web-ChatBot/server.js
+++ b/AS-FAQ-Web-ChatBot/server.js
@@ -44,18 +44,21 @@ app.use('/eip/askbot', limiter);
 app.use('/askbot', limiter);
 
 app.post(['/eip/askbot', '/askbot'], async (req, res) => { // "/eip/askbot" for webui dev, "/askbot" for local pc dev
-  const { question } = req.body;
+  const { question, chat_history } = req.body;
 
   if (!question) {
       return res.status(400).json({ error: '請提供問題' });
   }
+
+  const currentChatHistory = chat_history || [];
+
   // 呼叫 API 取得答案
   try {
     const apiUrl = `${process.env.BACKEND_URL}/ask`;
-    const response = await axios.post(apiUrl, { question });
-    const answer = response.data.answer;
+    const response = await axios.post(apiUrl, { question, chat_history: currentChatHistory });
+    const {answer, sources, chat_history: updatedChatHistory} = response.data.answer;
 
-    res.json({ answer });
+    res.json({ answer, sources, chat_history: updatedChatHistory });
   } catch (error) {
     console.error('Error calling API:', error);
     res.status(500).json({ error: 'API 呼叫失敗' });

--- a/AS-FAQ-Web-ChatBot/src/js/chatbot.js
+++ b/AS-FAQ-Web-ChatBot/src/js/chatbot.js
@@ -61,6 +61,7 @@ const chatMessages = $('#chat-messages');
 const chatBubble = $('#chat-bubble');
 const chatPopup = $('#chat-popup');
 const closePopup = $('#close-popup');
+let chatHistory = []; // 本地對話歷史紀錄
 
 // 載入語言資源並切換語言
 const langToggle = $('#lang-toggle');
@@ -233,7 +234,7 @@ function onUserRequest(message) {
     fetch('/askbot', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question: message })
+        body: JSON.stringify({ question: message, chat_history:chatHistory })
       })
     .then(response => {
         if (!response.ok) {
@@ -260,6 +261,15 @@ function onUserRequest(message) {
             chatBubble.html(safeHtml);
             // 讓所有超連結在新分頁開啟
             chatBubble.find('a').attr('target', '_blank').attr('rel', 'noopener noreferrer');
+        }
+
+        if (data.chat_history) {
+            chatHistory = data.chat_history;
+        } else {
+            chatHistory.push({
+                "User": message,
+                "Assistant": data.answer
+            });
         }
         // 送出按鈕變成送出，然後enable，可以再次送出
         $('#chat-submit').text(languages[currentLanguage].submit);


### PR DESCRIPTION
### Summary

This pull request introduces a new feature: **Context Caching**, enabling the chatbot to have a memory for multi-turn conversations. The system is no longer limited to a one-shot Q&A model and can now maintain conversational context across multiple interactions.

### Key Changes & Features

* **Multi-turn Conversation Support:** The chatbot can now understand and respond to follow-up questions by leveraging the context of previous conversations.
* **Decentralized Conversation History Management:** The conversation history is now maintained locally on each **front-end browser instance** rather than being managed centrally by the server or back-end.
* **Independent User Sessions:** This approach ensures that even with multiple users interacting with the chatbot simultaneously, each user's conversation history is **independent and does not interfere with others'.**

### How It Works
<img width="2895" height="735" alt="context-caching" src="https://github.com/user-attachments/assets/90d62965-452c-4acd-a854-c71e114063f7" />

1.  A new `chatHistory` variable is added to the front-end JavaScript (`chatbot.js`) to store the conversation history locally.
2.  When a user sends a new message, the full `chatHistory` is included in the API request body to the Node.js server (`server.js`).
3.  The Node.js server forwards this request, including `chat_history`, to the Python back-end (`respond.py`).
4.  The Python back-end formats the LLM prompt using the provided `chat_history`.
5.  After generating a response, the back-end updates the `chat_history` with the latest Q&A and returns it to the front-end.
6.  The front-end receives the updated history and uses it for subsequent conversations.

- `chatHistory` (in the front-end) and `chat_history` (in the back-end) are functionally the same thing. They both represent the complete conversation history. The difference in naming convention is primarily to distinguish their roles in different parts of the application: `chatHistory` for local, front-end management and `chat_history` for back-end processing.

### Remaining Tasks

* **UI Text Update:** The user interface still contains the text "目前僅一問一答，無記憶功能" (Currently one question at a time, no memory). If this feature is ready to be published, this text should be updated in a subsequent pull request to reflect the new functionality."